### PR TITLE
Fix a typo, RFC8633 is BCP 223

### DIFF
--- a/ntp-alternative-port.xml
+++ b/ntp-alternative-port.xml
@@ -76,7 +76,7 @@
         which has been exploited in large-scale DoS attacks on the Internet.
         Publicly accessible servers that support these modes need to be
         configured to not respond to requests using the modes, as recommended
-        in <xref target="RFC8633">BCP 233</xref>, but the number of
+        in <xref target="RFC8633">BCP 223</xref>, but the number of
         servers that still do that is significant enough to require specific
         mitigations.</t>
 


### PR DESCRIPTION
Hi,

https://tools.ietf.org/html/rfc8633 is BCP 223.

I think 233 is a typo.